### PR TITLE
add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
- - Rozzii
- - smoshiur1237
+- sles-ironic-python-agent-builder-maintainers
 
 reviewers:
- - kashifest
- - lentzi90
- - tuminoid
+- sles-ironic-python-agent-builder-maintainers
+- sles-ironic-python-agent-builder-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,11 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  sles-ironic-python-agent-builder-maintainers:
+  - Rozzii
+  - smoshiur1237
+
+  sles-ironic-python-agent-builder-reviewers:
+  - kashifest
+  - lentzi90
+  - tuminoid


### PR DESCRIPTION
OWNERS_ALIASES groups are needed for fair blunderbuss review requests.