### PR TITLE
Improve SSH and debug control variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,13 @@ Beyond installing the `ironic-python-agent`, `ironic-lib` and
   listen for raw data from stdin and write compressed data to stdout. Command
   can be with arguments.
 - Configures rescue mode if `DIB_IPA_ENABLE_RESCUE` is not set to `false`.
+- Removes build depedencies (like gcc) in the end and heavily optimizes the
+  image size by removing software that is not used by IPA, such as Perl, pip,
+  package managers, SSH, dracut and a lot more.
+- Installation of SSH can be controlled with `DIB_IPA_INSTALL_SSH` which is
+  false by default.
+- Installation of useful debugging utilities like ping, dmesg, and vim can be
+  controlled with `DIB_IPA_INSTALL_DEBUG_TOOLS` which is false by default.
 
 **note**
    Using the ram disk will require at least 1.5GB of RAM

--- a/ipa_builder_elements/sles-ipa-install/post-install.d/99-remove-extra-packages
+++ b/ipa_builder_elements/sles-ipa-install/post-install.d/99-remove-extra-packages
@@ -20,7 +20,7 @@ for folder in $KNOWN_FIRMWARE_PATH; do
 done
 
 # Don't remove these if you want to get ssh connection
-if [[ "${DIB_SLESIPA_INSTALL_SSH:-false}" = false ]]; then
+if [[ "${DIB_IPA_INSTALL_SSH:-false}" = "false" ]]; then
     zypper rm -y openssh-server \
         openssh-common \
         openssh-clients || true
@@ -91,13 +91,29 @@ zypper rm --clean-deps -y \
     rsync \
     rsyslog \
     smartmontools \
-    vim-small \
     xfsprogs \
     dracut \
     grub2 grub2-efi \
     python311-pip \
     perl \
     make || true
+
+# These are good for debugging
+if [[ "${DIB_IPA_INSTALL_DEBUG_TOOLS:-false}" = "false" ]]; then
+    zypper rm -y --clean-deps vim-small
+
+    rm -rf /usr/sbin/ss \
+    /usr/bin/du \
+    /usr/bin/dig \
+    /usr/bin/diff \
+    /usr/bin/top \
+    /usr/bin/ping \
+    /usr/bin/dmesg \
+    /usr/bin/mkdir \
+    /usr/bin/tail \
+    /usr/bin/chown \
+    /usr/bin/chmod
+fi
 
 # Finally we manually delete unused files and binaries.
 rm -rf /etc/profile.d \
@@ -286,18 +302,3 @@ rm -rf /usr/bin/zypper \
     /usr/bin/last \
     /usr/bin/join \
     /usr/bin/dnssec-cds
-
-# These are good for debugging
-if [[ "${DIB_SLESIPA_INSTALL_DEBUG:-false}" = false ]]; then
-    rm -rf /usr/sbin/ss \
-    /usr/bin/du \
-    /usr/bin/dig \
-    /usr/bin/diff \
-    /usr/bin/top \
-    /usr/bin/ping \
-    /usr/bin/dmesg \
-    /usr/bin/mkdir \
-    /usr/bin/tail \
-    /usr/bin/chown \
-    /usr/bin/chmod
-fi


### PR DESCRIPTION
Documents the recent changes and the two new control variables into readme and renames them to be in the same style as other control variables. Also adds vim to debug tools, hence the debug tools block is moved close to zypper remove block.